### PR TITLE
Fix intro sentence

### DIFF
--- a/speaking/index.md
+++ b/speaking/index.md
@@ -5,7 +5,7 @@ excerpt: "Prior Speaking Engagements"
 search_omit: false
 ---
 
-I am an accomplished, engaging speaking who has spoken at dozens of local, national, and international conferences.
+I am an accomplished, engaging speaker who has spoken at dozens of local, national, and international conferences.
 
 Some topics I speak about include:
 


### PR DESCRIPTION
I was reading your article [about Sean Griffin's Abstractions talk](http://daydreamsinruby.com/abstractions-pull-requests/) as well as your speaker bio, and I wanted to point out what I think may be a typo on your speaker bio page. I believe "speaking" in the first sentence was intended to be "speaker."

Also, thank you for your write up on Sean's talk! I'm going to be including a link to your post in a presentation for new developers that I'll be giving at area universities in the coming weeks. Your post is an excellent summary of an excellent talk, and I'm excited to pass it on to new developers!